### PR TITLE
Nit: correct unstructured example function name

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Or for creating an _unstructured_ object (without dynamic fields):
 import 'package:js/js_util.dart' as js;
 
 void main() {
-  var object = js.createObject();
+  var object = js.newObject();
   js.setProperty(object, 'anyName', 'anyValue');
 }
 ```


### PR DESCRIPTION
Just a quick s/js.createObject()/js.newObject()/ to fix the example:
https://pub.dartlang.org/documentation/js/latest/js_util/js_util-library.html